### PR TITLE
Added support for Traversable objects, other than arrays on some fns.

### DIFF
--- a/lib/Onebip/array.php
+++ b/lib/Onebip/array.php
@@ -3,6 +3,20 @@
 namespace Onebip;
 
 /*
+ * Variant of PHP's array_reduce, but it supports any traversable in input
+ * (arrays or objects instance Traversable) and is sensible to associative
+ * arrays, other than normal arrays.
+ */
+function array_reduce($array, callable $f, $acc)
+{
+    foreach ($array as $key => $value) {
+        $acc = call_user_func($f, $acc, $value, $key);
+    }
+
+    return $acc;
+}
+
+/*
  * Concatenates every parameters in an array. Parameters could be scalar values
  * or arrays. Doesn't preserve keys.
  *
@@ -37,7 +51,7 @@ function array_concat(/* $element, ... */)
  *        array_map([1, 2, 3], function($value) { return $value * 2; })
  *    );
  */
-function array_map(array $array, callable $mapper = null)
+function array_map($array, callable $mapper = null)
 {
     $mapped = [];
     $mapper = $mapper ?: function($value) { return $value; };
@@ -58,7 +72,7 @@ function array_map(array $array, callable $mapper = null)
  *                    'foo')
  *    );
  */
-function array_pluck(array $arrays, $column)
+function array_pluck($arrays, $column)
 {
     $plucked = [];
     foreach ($arrays as $array) {
@@ -85,12 +99,12 @@ function array_pluck(array $arrays, $column)
  *        array_flatten([1, [2, [3, [4, 5]]]])
  *    );
  */
-function array_flatten(array $array)
+function array_flatten($array)
 {
     return array_reduce(
         $array,
         function($acc, $item) {
-            if (is_array($item)) {
+            if (is_array($item) || $item instanceof \Traversable) {
                 return array_merge($acc, array_flatten($item));
             } else {
                 $acc[] = $item;
@@ -140,7 +154,7 @@ function array_all($array, callable $predicate)
  *          })
  *      );
  */
-function array_some(array $array, callable $predicate)
+function array_some($array, callable $predicate)
 {
     foreach ($array as $key => $value) {
         if (call_user_func($predicate, $value, $key, $array)) {
@@ -210,7 +224,7 @@ function array_cartesian_product(array $arrays)
  *            )
  *        );
  */
-function array_group_by(array $array, callable $f = null)
+function array_group_by($array, callable $f = null)
 {
     $f = $f ?: function($value) { return $value; };
     return array_reduce(

--- a/spec/Onebip/ArrayFlattenTest.php
+++ b/spec/Onebip/ArrayFlattenTest.php
@@ -12,4 +12,17 @@ class ArrayFlattenTest extends \PHPUnit_Framework_TestCase
             array_flatten([1, [2, [3, [4, [5]]]]])
         );
     }
+
+    public function testIterators()
+    {
+        $this->assertSame(
+            [1, 2, 3, 4, 5],
+            array_flatten(
+                new \ArrayIterator([1,
+                    new \ArrayIterator([2,
+                        new \ArrayIterator([3,
+                            new \ArrayIterator([4,
+                                new \ArrayIterator([5])])])])]))
+        );
+    }
 }

--- a/spec/Onebip/ArrayGroupByTest.php
+++ b/spec/Onebip/ArrayGroupByTest.php
@@ -29,4 +29,17 @@ class ArrayGroupByTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testIterator()
+    {
+        $this->assertSame(
+            [
+                1 => [1],
+                2 => [2, 2],
+                3 => [3, 3],
+                4 => [4],
+            ],
+            array_group_by(new \ArrayIterator([1, 2, 2, 3, 3, 4]))
+        );
+    }
 }

--- a/spec/Onebip/ArrayMapTest.php
+++ b/spec/Onebip/ArrayMapTest.php
@@ -12,6 +12,14 @@ class ArrayMapTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testIterator()
+    {
+        $this->assertSame(
+            [2, 4, 6],
+            array_map(new Range(1, 4), function($value) { return $value * 2; })
+        );
+    }
+
     public function testIdentity()
     {
         $this->assertSame([], array_map([]));

--- a/spec/Onebip/ArrayPluckTest.php
+++ b/spec/Onebip/ArrayPluckTest.php
@@ -14,6 +14,20 @@ class ArrayPluckTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testIterator()
+    {
+        $this->assertSame(
+            ['bar', 'bar'],
+            array_pluck(
+                new \ArrayIterator([
+                    ['foo' => 'bar', 'bis' => 'ter'],
+                    ['foo' => 'bar', 'bis' => 'ter']
+                ]),
+                'foo'
+            )
+        );
+    }
+
     public function testArrayPluckWithHoles()
     {
         $this->assertSame(

--- a/spec/Onebip/ArrayReduceTest.php
+++ b/spec/Onebip/ArrayReduceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Onebip;
+
+use function Onebip\array_reduce;
+
+class ArrayReduceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testArrayReduce()
+    {
+        $this->assertSame(
+            45,
+            array_reduce(
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                function ($acc, $n) { return $acc + $n; },
+                0
+            )
+        );
+    }
+
+    public function testIterator()
+    {
+        $this->assertSame(
+            45,
+            array_reduce(
+                new Range(0, 10),
+                function ($acc, $n) { return $acc + $n; },
+                0
+            )
+        );
+    }
+}

--- a/spec/Onebip/ArraySomeTest.php
+++ b/spec/Onebip/ArraySomeTest.php
@@ -10,4 +10,14 @@ class ArraySomeTest extends \PHPUnit_Framework_TestCase
             array_some([1, 2, 3], function($value) { return $value % 2 === 0; })
         );
     }
+
+    public function testIterator()
+    {
+        $this->assertTrue(
+            array_some(
+                new Range(1, 4),
+                function($value) { return $value % 2 === 0; }
+            )
+        );
+    }
 }


### PR DESCRIPTION
Additionally, added our own version of array_reduce, supporting Traversable objects too.
